### PR TITLE
fix: fix url encoding when querying iot_deviceupdate operational status

### DIFF
--- a/sdk/iot_deviceupdate/src/device_update.rs
+++ b/sdk/iot_deviceupdate/src/device_update.rs
@@ -183,8 +183,7 @@ impl DeviceUpdateClient {
 
         loop {
             sleep(Duration::from_secs(5)).await;
-            let mut uri = self.device_update_url.clone();
-            uri.set_path(&resp_body);
+            let uri = self.device_update_url.clone().join(&resp_body)?;
             debug!("Requesting operational status: {}", &uri);
             let update_operation: UpdateOperation = self.get(uri.to_string()).await?;
 


### PR DESCRIPTION
rather than using: 6574a71e-dc32-43e1-882c-d109e2710597 **%3F** api-version=2022-10-01,
the correct format should be: 6574a71e-dc32-43e1-882c-d109e2710597 **?** api-version=2022-10-01.
